### PR TITLE
Add --ask-vault-pass to deploy seed args

### DIFF
--- a/deploy
+++ b/deploy
@@ -42,6 +42,7 @@ def main():
             if args.secrets_repo_path:
                 cmd.extend(['-e', 'secrets_repo_path=%s'
                             % args.secrets_repo_path])
+            cmd.append('--ask-vault-pass')
         else:
             action = 'Deploying'
             cmd.append('autoland-ec2-provision.yml')


### PR DESCRIPTION
@globau The seed deploy command works but needs '--ask-vault-pass' in order to decrypt the secrets being seeded.