### PR TITLE
autoland: Please enable nspr on phabricator

### DIFF
--- a/ansible/host_vars/autoland.mozilla.org.yml
+++ b/ansible/host_vars/autoland.mozilla.org.yml
@@ -40,3 +40,6 @@ repos:
 
   fluent-migration:
     path: "/repos/fluent-migration"
+
+  nspr:
+    path: "/repos/nspr"


### PR DESCRIPTION
Summary: Please enable nspr on phabricator

Test Plan: NA

Reviewers: smacleod

Reviewed By: smacleod

Bug #: 1517428

Differential Revision: https://phabricator.services.mozilla.com/D16227